### PR TITLE
Update application-api references

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -103,7 +103,7 @@ jobs:
           make test
       - name: Run Gosec Security Scanner
         run: |
-          go install github.com/securego/gosec/v2/cmd/gosec@latest
+          go install github.com/securego/gosec/v2/cmd/gosec@v2.19.0
           make gosec
           if [[ $? != 0 ]]
           then

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -14,7 +14,7 @@ spec:
     value: '{{revision}}'
   - name: infra-deployment-update-script
     value: |
-        sed -i -e 's|\(https://github.com/redhat-appstudio/application-api/.*?ref=\)\(.*\)|\1{{ revision }}|' components/application-api/kustomization.yaml
+        sed -i -e 's|\(https://github.com/konflux-ci/application-api/.*?ref=\)\(.*\)|\1{{ revision }}|' components/application-api/kustomization.yaml
   pipelineSpec:
     params:
     - description: Source Repository URL

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ kustomize: ## Download kustomize locally if necessary.
 
 ENVTEST = $(shell pwd)/bin/setup-envtest
 envtest: ## Download envtest-setup locally if necessary.
-	$(call go-get-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
+	$(call go-get-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@395cfc7486e652d19fe1b544a436f9852ba26e4f)
 
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/crd | kubectl apply -f -

--- a/PROJECT
+++ b/PROJECT
@@ -5,7 +5,7 @@ plugins:
   manifests.sdk.operatorframework.io/v2: {}
   scorecard.sdk.operatorframework.io/v2: {}
 projectName: application-api
-repo: github.com/redhat-appstudio/application-api
+repo: github.com/konflux-ci/application-api
 resources:
 - api:
     crdVersion: v1
@@ -13,7 +13,7 @@ resources:
   domain: redhat.com
   group: appstudio
   kind: Application
-  path: github.com/redhat-appstudio/application-api/api/v1alpha1
+  path: github.com/konflux-ci/application-api/api/v1alpha1
   version: v1alpha1
 - api:
     crdVersion: v1
@@ -21,7 +21,7 @@ resources:
   domain: redhat.com
   group: appstudio
   kind: Component
-  path: github.com/redhat-appstudio/application-api/api/v1alpha1
+  path: github.com/konflux-ci/application-api/api/v1alpha1
   version: v1alpha1
 - api:
     crdVersion: v1
@@ -29,7 +29,7 @@ resources:
   domain: redhat.com
   group: appstudio
   kind: ComponentDetectionQuery
-  path: github.com/redhat-appstudio/application-api/api/v1alpha1
+  path: github.com/konflux-ci/application-api/api/v1alpha1
   version: v1alpha1
 - api:
     crdVersion: v1
@@ -37,7 +37,7 @@ resources:
   domain: redhat.com
   group: appstudio
   kind: SnapshotEnvironmentBinding
-  path: github.com/redhat-appstudio/application-api/api/v1alpha1
+  path: github.com/konflux-ci/application-api/api/v1alpha1
   version: v1alpha1
 - api:
     crdVersion: v1
@@ -45,7 +45,7 @@ resources:
   domain: redhat.com
   group: appstudio
   kind: Snapshot
-  path: github.com/redhat-appstudio/application-api/api/v1alpha1
+  path: github.com/konflux-ci/application-api/api/v1alpha1
   version: v1alpha1
 - api:
     crdVersion: v1
@@ -53,7 +53,7 @@ resources:
   domain: redhat.com
   group: appstudio
   kind: PromotionRun
-  path: github.com/redhat-appstudio/application-api/api/v1alpha1
+  path: github.com/konflux-ci/application-api/api/v1alpha1
   version: v1alpha1
 - api:
     crdVersion: v1
@@ -61,14 +61,14 @@ resources:
   domain: redhat.com
   group: appstudio
   kind: Environment
-  path: github.com/redhat-appstudio/application-api/api/v1alpha1
+  path: github.com/konflux-ci/application-api/api/v1alpha1
   version: v1alpha1
 - api:
     crdVersion: v1
   domain: redhat.com
   group: appstudio
   kind: DeploymentTargetClass
-  path: github.com/redhat-appstudio/application-api/api/v1alpha1
+  path: github.com/konflux-ci/application-api/api/v1alpha1
   version: v1alpha1
 - api:
     crdVersion: v1
@@ -76,7 +76,7 @@ resources:
   domain: redhat.com
   group: appstudio
   kind: DeploymentTargetClaim
-  path: github.com/redhat-appstudio/application-api/api/v1alpha1
+  path: github.com/konflux-ci/application-api/api/v1alpha1
   version: v1alpha1
 - api:
     crdVersion: v1
@@ -84,6 +84,6 @@ resources:
   domain: redhat.com
   group: appstudio
   kind: DeploymentTarget
-  path: github.com/redhat-appstudio/application-api/api/v1alpha1
+  path: github.com/konflux-ci/application-api/api/v1alpha1
   version: v1alpha1
 version: "3"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/redhat-appstudio/application-api
+module github.com/konflux-ci/application-api
 
 go 1.19
 


### PR DESCRIPTION
## Description
Updates the references to `redhat-appstudio/application-api` to `konflux-ci/application-api` as part of the DEVHAS-604 epic.

## Related issue
https://issues.redhat.com/browse/DEVHAS-657